### PR TITLE
Patch3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: Rust
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Install build dependencies
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: |
+          libunwind-dev \
+          libclang-dev \
+          pkg-config \
+          build-essential \
+          curl \
+          wget \
+          gnupg \
+          git \
+          ca-certificates \
+          libgit2-dev \
+          libmount-dev \
+          libsepol-dev \
+          libselinux1-dev \
+          libglib2.0-dev \
+          libgudev-1.0-dev \
+          libgstreamer-plugins-base1.0-dev \
+          libgstreamer1.0-dev
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Use cached dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: "${{ hashFiles('**/Cargo.lock') }}"
+        shared-key: "shared"
+
+    - name: Install build dependencies - Rustup
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable -y
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+    - name: Check style
+      run: cargo fmt --check
+
+    - name: Check clippy
+      run: cargo clippy --all-features --locked
+
+    - name: Build
+      run: cargo build --verbose --locked
+
+    - name: Install runtime dependencies
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: |
+          gstreamer1.0-tools
+
+    - name: Run tests
+      run: cargo test --verbose --locked -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +318,17 @@ name = "g2poly"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af6a86e750338603ea2c14b1c0bfe58cd61f87ca67a0021d9334996024608e12"
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "gif"
@@ -616,6 +636,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +667,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +697,44 @@ name = "muldiv"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
+
+[[package]]
+name = "nalgebra"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-integer"
@@ -688,6 +762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -741,6 +816,12 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-crate"
@@ -799,6 +880,7 @@ dependencies = [
  "once_cell",
  "qrc",
  "rqrr",
+ "statrs",
 ]
 
 [[package]]
@@ -809,6 +891,52 @@ checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -839,6 +967,15 @@ dependencies = [
  "g2p",
  "image",
  "lru",
+]
+
+[[package]]
+name = "safe_arch"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3460605018fdc9612bce72735cba0d27efbcd9904780d44c7e3a9948f96148a"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -877,6 +1014,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +1054,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "statrs"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f697a07e4606a0a25c044de247e583a330dbb1731d11bc7350b81f48ad567255"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -1024,6 +1186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1208,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1100,6 +1274,16 @@ name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+
+[[package]]
+name = "wide"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a040b111774ab63a19ef46bbc149398ab372b4ccdcfd719e9814dbd7dfd76c8"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +48,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +61,29 @@ checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "atomic_refcell"
@@ -55,6 +96,29 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "av1-grain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6678909d8c5d46a42abcf571271e15fdbc0a225e3646cf23762cd415046c78bf"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876c75a42f6364451a033496a14c44bffe41f5f4a8236f697391f11024e596d2"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "bit_field"
@@ -75,6 +139,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
+name = "bitstream-io"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415f8399438eb5e4b2f73ed3152a3448b98149dda642a957ee704e1daa5cf1d8"
+
+[[package]]
+name = "built"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a6c0b39c38fd754ac338b00a88066436389c0f029da5d37d1e01091d9b7c17"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,10 +169,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "cc"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+dependencies = [
+ "jobserver",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "cfg-expr"
@@ -431,7 +518,7 @@ dependencies = [
  "futures-util",
  "glib",
  "gstreamer-sys",
- "itertools",
+ "itertools 0.13.0",
  "libc",
  "muldiv",
  "num-integer",
@@ -526,18 +613,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -587,13 +669,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd54d660e773627692c524beaad361aca785a4f9f5730ce91f42aabe5bce3d11"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d730b085583c4d789dfd07fdcf185be59501666a90c97c40162b37e4fdad272d"
+dependencies = [
+ "byteorder-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "imgref"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126"
+
+[[package]]
 name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -603,6 +744,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -636,6 +786,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "once_cell",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,12 +819,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
-name = "lru"
-version = "0.9.0"
+name = "loop9"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
- "hashbrown 0.13.2",
+ "imgref",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -677,10 +847,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -728,12 +914,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -751,6 +980,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -842,6 +1072,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
+dependencies = [
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,7 +1106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f64ee6dc98fa28fec2e13ebcbe910530ef3b82a733853d48a7c98ffc0c534e"
 dependencies = [
  "flate2",
- "image",
+ "image 0.24.9",
  "qrcode",
 ]
 
@@ -876,12 +1125,18 @@ dependencies = [
  "gstreamer",
  "gstreamer-base",
  "gstreamer-video",
- "image",
+ "image 0.25.1",
  "once_cell",
  "qrc",
  "rqrr",
  "statrs",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -933,6 +1188,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
+dependencies = [
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.12.1",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "profiling",
+ "rand",
+ "rand_chacha",
+ "simd_helpers",
+ "system-deps",
+ "thiserror",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67376f469e7e7840d0040bbf4b9b3334005bb167f814621326e4c7ab8cd6e944"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,13 +1264,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "rqrr"
-version = "0.6.0"
+name = "rgb"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8b87d1f9f69bb1a6c77e20fd303f9617b2b68dcff87cd9bcbfff2ced4b8a0b"
+checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "rqrr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0cd0432e6beb2f86aa4c8af1bb5edcf3c9bcb9d4836facc048664205458575"
 dependencies = [
  "g2p",
- "image",
+ "image 0.25.1",
  "lru",
 ]
 
@@ -1031,6 +1345,15 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
 
 [[package]]
 name = "slab"
@@ -1196,6 +1519,17 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "v_frame"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version-compare"
@@ -1406,10 +1740,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
 name = "zune-inflate"
 version = "0.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec866b44a2a1fd6133d363f073ca1b179f438f99e7e5bfb1e33f7181facfe448"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ path = "src/lib.rs"
 [build-dependencies]
 gst-plugin-version-helper = "0.8.2"
 
+[dev-dependencies]
+statrs = "0.17.1"
+
 [dependencies]
 glib = "0.19"
 gst = { package = "gstreamer", version = "0.22", features = ["v1_16"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ lto = true
 opt-level = 3
 debug = true
 panic = 'unwind'
+strip = true
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ gst = { package = "gstreamer", version = "0.22", features = ["v1_16"] }
 gst-base = { package = "gstreamer-base", version = "0.22", features = ["v1_16"] }
 gst-video = { package = "gstreamer-video", version = "0.22", features = ["v1_16"] }
 
-image = "0.24"
+image = "0.25"
 once_cell = "1.19.0"
 qrc = "0.0.5" # Encode
-rqrr = "0.6" # Decode, TODO: Use it to replace qrc
+rqrr = "0.7" # Decode, TODO: Use it to replace qrc
 
 [profile.release]
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@ mod qrsink;
 mod qrsrc;
 
 pub const MINIMUM_SIZE: u32 = 100;
-pub const MINIMUM_FPS: i32 = 10;
-pub const MAXIMUM_FPS: i32 = 240;
+pub const MINIMUM_FPS: i32 = 1;
+pub const MAXIMUM_FPS: i32 = 1000;
 
 fn plugin_init(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
     qrsink::register(plugin)?;

--- a/src/qrsink/imp.rs
+++ b/src/qrsink/imp.rs
@@ -38,10 +38,6 @@ impl ObjectSubclass for QRTimeStampSink {
 }
 
 impl ObjectImpl for QRTimeStampSink {
-    fn constructed(&self) {
-        self.parent_constructed();
-    }
-
     fn signals() -> &'static [glib::subclass::Signal] {
         static SIGNALS: Lazy<Vec<glib::subclass::Signal>> = Lazy::new(|| {
             vec![glib::subclass::Signal::builder("on-render")

--- a/src/qrsink/imp.rs
+++ b/src/qrsink/imp.rs
@@ -75,7 +75,9 @@ impl ElementImpl for QRTimeStampSink {
                 .format_list([gst_video::VideoFormat::Rgb])
                 .height_range(MINIMUM_SIZE as i32..i32::MAX)
                 .width_range(MINIMUM_SIZE as i32..i32::MAX)
-                .framerate_range(gst::Fraction::from(MINIMUM_FPS)..gst::Fraction::from(MAXIMUM_FPS))
+                .framerate_range(
+                    gst::Fraction::from(MINIMUM_FPS)..=gst::Fraction::from(MAXIMUM_FPS),
+                )
                 .build();
             // The src pad template must be named "src" for basesrc
             // and specific a pad that is always there

--- a/src/qrsink/imp.rs
+++ b/src/qrsink/imp.rs
@@ -101,8 +101,10 @@ impl BaseSinkImpl for QRTimeStampSink {
         // Here you would parse the caps to ensure they are what you expect
         gst::info!(CAT, "Caps set: {caps}");
 
-        let info = gst_video::VideoInfo::from_caps(caps)
-            .map_err(|_| gst::loggable_error!(CAT, "Failed to build `VideoInfo` from caps {caps}"));
+        let info = gst_video::VideoInfo::from_caps(caps).map_err(|_| {
+            gst::loggable_error!(CAT, "Failed to build `VideoInfo` from caps {caps}")
+        })?;
+
         self.state.lock().unwrap().info = info.ok();
         Ok(())
     }

--- a/src/qrsink/imp.rs
+++ b/src/qrsink/imp.rs
@@ -1,4 +1,5 @@
 use gst::glib;
+use gst::prelude::*;
 use gst::subclass::prelude::*;
 use gst_base::subclass::prelude::*;
 use gst_video::{VideoFrameExt, VideoFrameRef};
@@ -39,6 +40,16 @@ impl ObjectSubclass for QRTimeStampSink {
 impl ObjectImpl for QRTimeStampSink {
     fn constructed(&self) {
         self.parent_constructed();
+    }
+
+    fn signals() -> &'static [glib::subclass::Signal] {
+        static SIGNALS: Lazy<Vec<glib::subclass::Signal>> = Lazy::new(|| {
+            vec![glib::subclass::Signal::builder("on-render")
+                .param_types([gst_video::VideoInfo::static_type(), i64::static_type()])
+                .build()]
+        });
+
+        SIGNALS.as_ref()
     }
 }
 
@@ -134,10 +145,16 @@ impl BaseSinkImpl for QRTimeStampSink {
         let (_meta, content) = grids[0].decode().unwrap();
         let content = content.parse::<u128>().unwrap();
         let diff = if time.as_millis() > content {
-            time.as_millis() - content
+            (time.as_millis() - content) as i64
         } else {
             0
         };
+
+        if let Some(info) = &self.state.lock().unwrap().info {
+            let obj = self.obj();
+            obj.emit_by_name::<()>("on-render", &[&info, &diff]);
+        }
+
         gst::debug!(
             CAT,
             imp: self,

--- a/src/qrsink/imp.rs
+++ b/src/qrsink/imp.rs
@@ -101,14 +101,12 @@ impl BaseSinkImpl for QRTimeStampSink {
             gst::loggable_error!(CAT, "Failed to build `VideoInfo` from caps {caps}")
         })?;
 
-        self.state.lock().unwrap().info = info.ok();
+        self.state.lock().unwrap().info.replace(info);
+
         Ok(())
     }
 
     fn render(&self, buffer: &gst::Buffer) -> Result<gst::FlowSuccess, gst::FlowError> {
-        let Some(info) = self.state.lock().unwrap().info.clone() else {
-            return Ok(gst::FlowSuccess::Ok);
-        };
         // We need to get time asap to avoid adding the time to the decode logic
         let time = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/src/qrsrc/imp.rs
+++ b/src/qrsrc/imp.rs
@@ -133,6 +133,16 @@ impl ObjectImpl for QRTimeStampSrc {
             _ => unimplemented!(),
         }
     }
+
+    fn signals() -> &'static [glib::subclass::Signal] {
+        static SIGNALS: Lazy<Vec<glib::subclass::Signal>> = Lazy::new(|| {
+            vec![glib::subclass::Signal::builder("on-create")
+                .param_types([gst_video::VideoInfo::static_type()])
+                .build()]
+        });
+
+        SIGNALS.as_ref()
+    }
 }
 
 impl GstObjectImpl for QRTimeStampSrc {}
@@ -435,6 +445,11 @@ impl PushSrcImpl for QRTimeStampSrc {
                 gst::debug!(CAT, imp: self, "Flushing");
                 return Err(gst::FlowError::Flushing);
             }
+        }
+
+        if let Some(info) = &self.state.lock().unwrap().info {
+            let obj = self.obj();
+            obj.emit_by_name::<()>("on-create", &[&info]);
         }
 
         Ok(CreateSuccess::NewBuffer(buffer))

--- a/src/qrsrc/imp.rs
+++ b/src/qrsrc/imp.rs
@@ -167,7 +167,9 @@ impl ElementImpl for QRTimeStampSrc {
                 .format_list([gst_video::VideoFormat::Rgb])
                 .height_range(MINIMUM_SIZE as i32..i32::MAX)
                 .width_range(MINIMUM_SIZE as i32..i32::MAX)
-                .framerate_range(gst::Fraction::from(MINIMUM_FPS)..gst::Fraction::from(MAXIMUM_FPS))
+                .framerate_range(
+                    gst::Fraction::from(MINIMUM_FPS)..=gst::Fraction::from(MAXIMUM_FPS),
+                )
                 .build();
             // The src pad template must be named "src" for basesrc
             // and specific a pad that is always there

--- a/src/qrsrc/imp.rs
+++ b/src/qrsrc/imp.rs
@@ -39,7 +39,7 @@ struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Settings {
-            fps: gst::Fraction::from((DEFAULT_FPS, 1)),
+            fps: gst::Fraction::from(DEFAULT_FPS),
             width: DEFAULT_SIZE,
             height: DEFAULT_SIZE,
             num_buffers: -1,

--- a/src/qrsrc/imp.rs
+++ b/src/qrsrc/imp.rs
@@ -85,10 +85,13 @@ impl ObjectImpl for QRTimeStampSrc {
     fn constructed(&self) {
         self.parent_constructed();
 
+        // Set the obj defaults
         let obj = self.obj();
         obj.set_live(true);
         obj.set_format(gst::Format::Time);
         obj.set_num_buffers(-1);
+        obj.set_automatic_eos(true);
+        obj.set_do_timestamp(false);
     }
 
     fn signals() -> &'static [glib::subclass::Signal] {

--- a/tests/diff_test.rs
+++ b/tests/diff_test.rs
@@ -1,0 +1,145 @@
+use gst::prelude::*;
+use std::sync::{Arc, Mutex};
+
+fn prepare() {
+    gst::init().unwrap();
+
+    gstqrtimestamp::plugin_register_static().unwrap();
+}
+
+#[test]
+/// Here we are creating a pipeline with a queue that adds a fixed time delay, so we can assert the correctness of the computed latency (diff)
+fn main() {
+    prepare();
+
+    // Build the test pipeline
+    let fps = 100;
+    let queue_buffers = 10;
+    let latency = std::time::Duration::from_secs_f64((queue_buffers as f64) / (fps as f64));
+    let minimum_test_bufferrs = 100;
+    let buffers = 1 + minimum_test_bufferrs + queue_buffers;
+    dbg!(&queue_buffers, &fps, &latency, &buffers);
+    let pipeline_description = format!(
+        concat!(
+            "qrtimestampsrc name=src num-buffers={buffers} do-timestamp=true",
+            " ! video/x-raw,framerate={fps}/1",
+            " ! queue leaky=downstream silent=true",
+            " max-size-buffers={queue_buffers} min-threshold-buffers={queue_buffers}", // Limit in buffers
+            " max-size-bytes=0 min-threshold-bytes=0", // Disable bytes
+            " max-size-time=0 min-threshold-time=0",   // Disable time
+            " ! qrtimestampsink name=sink sync=false",
+        ),
+        buffers = buffers,
+        fps = fps,
+        queue_buffers = queue_buffers as u64,
+    );
+    let pipeline = gst::parse::launch(&pipeline_description)
+        .unwrap()
+        .downcast::<gst::Pipeline>()
+        .unwrap();
+
+    // Gather all latencies
+    let latencies = Arc::new(Mutex::new(Vec::with_capacity(buffers)));
+    let latencies_cloned = latencies.clone();
+    let qrtimestampsink = pipeline.by_name("sink").unwrap();
+    qrtimestampsink.connect("on-render", false, move |values| {
+        let _element = values[0].get::<gst::Element>().expect("Invalid argument");
+        let _info = values[1]
+            .get::<gst_video::VideoInfo>()
+            .expect("Invalid argument");
+        let diff = values[2].get::<i64>().expect("Invalid argument");
+
+        latencies_cloned.lock().unwrap().push(diff);
+
+        None
+    });
+
+    // Start
+    pipeline.set_state(gst::State::Playing).unwrap();
+
+    // Wait for EOS
+    let bus = pipeline.bus().unwrap();
+    for msg in bus.iter_timed(gst::ClockTime::NONE) {
+        use gst::MessageView;
+
+        match msg.view() {
+            MessageView::Eos(..) => {
+                println!("EOS Recived");
+                break;
+            }
+            MessageView::Error(err) => {
+                eprintln!(
+                    "Error from {:?}: {} ({:?})",
+                    err.src().map(|s| s.path_string()),
+                    err.error(),
+                    err.debug()
+                );
+                break;
+            }
+            MessageView::Latency(_latency) => {
+                pipeline.recalculate_latency().unwrap();
+            }
+            _ => (),
+        }
+    }
+
+    // Cleanup
+    pipeline.set_state(gst::State::Null).unwrap();
+    while pipeline.current_state() != gst::State::Null {
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+
+    // Preparing results
+    let latencies = latencies.lock().unwrap();
+    // Notes:
+    //      1. We are skipping the first frame as it will always have a high value, possibly from the negotiation
+    //      2. We are skipping the last frames because they are the ones that were retained in the queue,
+    //      thus as there is no more frames coming in, they are released faster, which lowers their latency
+    let latencies = &latencies.iter().map(|i| *i as f64).collect::<Vec<_>>()
+        [1..=latencies.len() - queue_buffers];
+    dbg!(&latencies);
+
+    let jitters = &latencies
+        .windows(2)
+        .map(|a| a[1] - a[0])
+        .collect::<Vec<_>>()[..];
+    dbg!(&jitters);
+
+    let expected_latency = latency.as_millis() as f64;
+    let expected_max_jitter = 1f64;
+
+    // Asserts
+    use statrs::statistics::Statistics;
+    let latency_min = latencies.min();
+    let latency_max = latencies.max();
+    let latency_mean = latencies.mean();
+    let latency_std_dev = latencies.std_dev();
+    let latency_variance = latencies.variance();
+    let jitter_min = jitters.min();
+    let jitter_max = jitters.max();
+    let jitter_mean = jitters.mean();
+    let jitter_std_dev = jitters.std_dev();
+    let jitter_variance = jitters.variance();
+
+    dbg!(
+        &latency_min,
+        &latency_max,
+        &latency_mean,
+        &latency_std_dev,
+        &latency_variance
+    );
+    dbg!(
+        &jitter_min,
+        &jitter_max,
+        &jitter_mean,
+        &jitter_std_dev,
+        &jitter_variance
+    );
+
+    dbg!(&expected_latency, &expected_max_jitter);
+
+    assert!(latency_mean >= expected_latency - expected_max_jitter);
+    assert!(latency_max <= expected_latency + expected_max_jitter);
+    assert!(jitter_mean <= expected_max_jitter);
+    assert!(jitter_max <= expected_max_jitter);
+}

--- a/tests/info_test.rs
+++ b/tests/info_test.rs
@@ -1,0 +1,107 @@
+use gst::prelude::*;
+use gstqrtimestamp::MAXIMUM_FPS;
+use std::sync::{Arc, Mutex};
+
+fn prepare() {
+    gst::init().unwrap();
+
+    gstqrtimestamp::plugin_register_static().unwrap();
+}
+
+#[test]
+fn main() {
+    prepare();
+
+    // Build the test pipeline
+    let buffers = 10;
+    let fps = MAXIMUM_FPS;
+    let pipeline = gst::parse::launch(&format!(
+        concat!(
+            "qrtimestampsrc name=src num-buffers={buffers}",
+            " ! video/x-raw,framerate={fps}/1",
+            " ! qrtimestampsink name=sink",
+        ),
+        buffers = buffers,
+        fps = fps,
+    ))
+    .unwrap()
+    .downcast::<gst::Pipeline>()
+    .unwrap();
+
+    // Gather all sent infos
+    let sent_infos = Arc::new(Mutex::new(Vec::with_capacity(buffers)));
+    let sent_infos_cloned = sent_infos.clone();
+    let qrtimestampsrc = pipeline.by_name("src").unwrap();
+    qrtimestampsrc.connect("on-create", false, move |values| {
+        let _element = values[0].get::<gst::Element>().expect("Invalid argument");
+        let info = values[1]
+            .get::<gst_video::VideoInfo>()
+            .expect("Invalid argument");
+
+        sent_infos_cloned.lock().unwrap().push(info);
+
+        None
+    });
+
+    // Gather all received infos
+    let recv_infos = Arc::new(Mutex::new(Vec::with_capacity(buffers)));
+    let recv_infos_cloned = recv_infos.clone();
+    let qrtimestampsink = pipeline.by_name("sink").unwrap();
+    qrtimestampsink.connect("on-render", false, move |values| {
+        let _element = values[0].get::<gst::Element>().expect("Invalid argument");
+        let info = values[1]
+            .get::<gst_video::VideoInfo>()
+            .expect("Invalid argument");
+
+        recv_infos_cloned.lock().unwrap().push(info);
+
+        None
+    });
+
+    // Start
+    pipeline.set_state(gst::State::Playing).unwrap();
+
+    // Wait for EOS
+    let bus = pipeline.bus().unwrap();
+    for msg in bus.iter_timed(gst::ClockTime::NONE) {
+        use gst::MessageView;
+
+        match msg.view() {
+            MessageView::Eos(..) => {
+                println!("EOS Recived");
+                break;
+            }
+            MessageView::Error(err) => {
+                eprintln!(
+                    "Error from {:?}: {} ({:?})",
+                    err.src().map(|s| s.path_string()),
+                    err.error(),
+                    err.debug()
+                );
+                break;
+            }
+            MessageView::Latency(_latency) => {
+                pipeline.recalculate_latency().unwrap();
+            }
+            _ => (),
+        }
+    }
+
+    // Cleanup
+    pipeline.set_state(gst::State::Null).unwrap();
+    while pipeline.current_state() != gst::State::Null {
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+
+    // Asserts
+    let sent = sent_infos.lock().unwrap();
+    let recv = recv_infos.lock().unwrap();
+    let all_same = !recv
+        .iter()
+        .zip(sent.iter())
+        .any(|(recv, sent)| !recv.eq(sent));
+
+    dbg!(&sent[0], &recv[0]);
+
+    assert!(all_same, "{recv:#?}\n{sent:#?}");
+}


### PR DESCRIPTION
Built on top of #3, this PR has fundamental changes in how the plugin timing happens: instead of blocking the plugin until the next time tick, we use the technique implemented by videotessrc, in which it sets the frame timings and the underlying scheduler is responsible for calling our create implementation in time.

The major differences are:
- fixes deadlocks on some pipelines;
- lower the jitter
- now qrtimestampsink doesn't need a capsfilter before it when receiving via udp or if we have a queue between it and qrtimestampsrc

Aside from these changes, this patch also adds an integration test to (1) ensure latency is reported correctly, and (2) VideoInfo send is the same as the received one.

To be merged after #3